### PR TITLE
Fix video playback and migrate to KSP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0"
-    // ✅ kapt プラグイン追加
-    id("org.jetbrains.kotlin.kapt")
+    id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -93,7 +92,7 @@ dependencies {
     // ✅ Room Database（将来のキャッシュ機能用）
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")
-    kapt("androidx.room:room-compiler:2.6.1") // ✅ kapt使用
+    ksp("androidx.room:room-compiler:2.6.1")
 
     // HTTP通信（OneDrive API）
     implementation("com.squareup.okhttp3:okhttp:4.12.0")

--- a/app/src/main/java/com/example/tvmoview/data/repository/OneDriveRepository.kt
+++ b/app/src/main/java/com/example/tvmoview/data/repository/OneDriveRepository.kt
@@ -224,9 +224,13 @@ class OneDriveRepository(
                 when {
                     item.isVideo || item.isImage -> {
                         val downloadUrl = getDownloadUrl(item.id)
+                        val duration = if (item.isVideo && downloadUrl != null) {
+                            fetchDuration(downloadUrl)
+                        } else 0L
                         item.copy(
                             downloadUrl = downloadUrl,
-                            thumbnailUrl = generateThumbnailUrl(item)
+                            thumbnailUrl = generateThumbnailUrl(item),
+                            duration = duration
                         )
                     }
                     else -> item
@@ -244,6 +248,18 @@ class OneDriveRepository(
             "https://graph.microsoft.com/v1.0/me/drive/items/${item.id}/thumbnails/0/medium/content"
         } else {
             null
+        }
+    }
+
+    private fun fetchDuration(url: String): Long {
+        return try {
+            val retriever = android.media.MediaMetadataRetriever()
+            retriever.setDataSource(url, HashMap())
+            val duration = retriever.extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: 0L
+            retriever.release()
+            duration
+        } catch (e: Exception) {
+            0L
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
     id("com.android.application") version "8.2.0" apply false
     id("org.jetbrains.kotlin.android") version "2.0.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
-    id("org.jetbrains.kotlin.kapt") version "2.0.0" apply false
+    id("com.google.devtools.ksp") version "2.0.20-1.0.24" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.10.1"
 kotlin = "2.0.21"
+ksp = "2.0.20-1.0.24"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -24,9 +25,11 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+ksp-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 


### PR DESCRIPTION
## Summary
- enable KSP plugin and remove kapt usage
- decode video URLs using repository and load asynchronously
- compute video duration using MediaMetadataRetriever
- remove debug overlay from player screen

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6863e7b88ba4832c9929a7a285fca65a