### PR TITLE
Fix video playback URL fetching

### DIFF
--- a/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
@@ -288,12 +288,21 @@ private fun formatTime(timeMs: Long): String {
 // 動画URL取得（OneDrive統合版）
 
 private suspend fun resolveVideoUrl(itemId: String, downloadUrl: String): String {
-    return if (downloadUrl.isNotEmpty()) {
-        Log.d("VideoPlayer", "✅ downloadURL使用: $itemId")
-        downloadUrl
-    } else {
-        Log.d("VideoPlayer", "⚠️ downloadURL null、OneDriveから取得試行: $itemId")
-        MainActivity.oneDriveRepository.getDownloadUrl(itemId) ?: getTestVideoUrl(itemId)
+    // 再生直前で常に最新のURLを取得する
+    val freshUrl = MainActivity.oneDriveRepository.getDownloadUrl(itemId)
+    return when {
+        freshUrl != null -> {
+            Log.d("VideoPlayer", "✅ downloadURL取得成功: $itemId")
+            freshUrl
+        }
+        downloadUrl.isNotEmpty() -> {
+            Log.d("VideoPlayer", "⚠️ 新規URL取得失敗、既存downloadURL使用: $itemId")
+            downloadUrl
+        }
+        else -> {
+            Log.d("VideoPlayer", "⚠️ downloadURL未取得、テストURL使用: $itemId")
+            getTestVideoUrl(itemId)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- fetch a fresh OneDrive download URL right before playback, fall back to cached or test URL

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6863ec636750832ca2555e98626d776d