### PR TITLE
Improve player UX and add resume position

### DIFF
--- a/app/src/main/java/com/example/tvmoview/data/prefs/UserPreferences.kt
+++ b/app/src/main/java/com/example/tvmoview/data/prefs/UserPreferences.kt
@@ -21,4 +21,15 @@ object UserPreferences {
     var tileColumns: Int
         get() = prefs.getInt("tile_columns", 4)
         set(value) { prefs.edit().putInt("tile_columns", value).apply() }
+
+    fun getResumePosition(id: String): Long =
+        prefs.getLong("resume_" + id, 0L)
+
+    fun setResumePosition(id: String, position: Long) {
+        prefs.edit().putLong("resume_" + id, position).apply()
+    }
+
+    fun clearResumePosition(id: String) {
+        prefs.edit().remove("resume_" + id).apply()
+    }
 }

--- a/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
@@ -173,30 +173,19 @@ class MediaBrowserViewModel : ViewModel() {
     }
 
     private fun applySorting(items: List<MediaItem>): List<MediaItem> {
-        val sorted = when (_sortBy.value) {
-            SortBy.NAME -> items.sortedWith(
-                compareBy<MediaItem> { !it.isFolder }
-                    .thenBy { it.name.lowercase() }
-            )
-            SortBy.DATE -> items.sortedWith(
-                compareBy<MediaItem> { !it.isFolder }
-                    .thenBy { it.lastModified }
-            )
-            SortBy.SIZE -> items.sortedWith(
-                compareBy<MediaItem> { !it.isFolder }
-                    .thenBy { it.size }
-            )
-            SortBy.TYPE -> items.sortedWith(
-                compareBy<MediaItem> { !it.isFolder }
-                    .thenBy { it.mimeType ?: "" }
-                    .thenBy { it.name.lowercase() }
-            )
-            SortBy.SHOOT -> items.sortedWith(
-                compareBy<MediaItem> { !it.isFolder }
-                    .thenBy { it.lastModified }
-            )
+        val comparator = when (_sortBy.value) {
+            SortBy.NAME -> compareBy<MediaItem> { it.name.lowercase() }
+            SortBy.DATE -> compareBy<MediaItem> { it.lastModified }
+            SortBy.SIZE -> compareBy<MediaItem> { it.size }
+            SortBy.TYPE -> compareBy<MediaItem> { it.mimeType ?: "" }.thenBy { it.name.lowercase() }
+            SortBy.SHOOT -> compareBy<MediaItem> { it.lastModified }
         }
-        return if (_sortOrder.value == SortOrder.DESC) sorted.reversed() else sorted
+
+        val folders = items.filter { it.isFolder }.sortedWith(comparator)
+        val files = items.filter { !it.isFolder }.sortedWith(comparator)
+
+        val orderedFiles = if (_sortOrder.value == SortOrder.DESC) files.reversed() else files
+        return folders + orderedFiles
     }
 
     private fun displayItemsProgressive(allItems: List<MediaItem>) {


### PR DESCRIPTION
## Summary
- track resume position in `UserPreferences`
- update `HighQualityPlayerScreen` to resume playback, show loading and improved back/seek behaviour
- keep folders sorted first regardless of sort order

## Testing
- `./gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6864c9f25184832cb7a512ccef7c026f