### PR TITLE
Implement adaptable TV grid

### DIFF
--- a/app/src/main/java/com/example/tvmoview/data/prefs/UserPreferences.kt
+++ b/app/src/main/java/com/example/tvmoview/data/prefs/UserPreferences.kt
@@ -22,6 +22,10 @@ object UserPreferences {
         get() = prefs.getInt("tile_columns", 4)
         set(value) { prefs.edit().putInt("tile_columns", value).apply() }
 
+    var tileHeight: Int
+        get() = prefs.getInt("tile_height", 180)
+        set(value) { prefs.edit().putInt("tile_height", value).apply() }
+
     fun getResumePosition(id: String): Long =
         prefs.getLong("resume_" + id, 0L)
 

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
@@ -29,14 +31,17 @@ fun ModernMediaCard(
     item: MediaItem,
     onClick: () -> Unit,
     loadPriority: Float = 0.5f,
-    showName: Boolean = true
+    showName: Boolean = true,
+    height: Dp = 180.dp,
+    aspectRatio: Float = 16f / 9f
 ) {
     Card(
         modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(1f)
+            .height(height)
+            .aspectRatio(aspectRatio)
             .clickable { onClick() },
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        shape = RoundedCornerShape(6.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {  // ColumnからBoxに変更
             // サムネイル/アイコン表示部分

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernTileView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernTileView.kt
@@ -3,23 +3,29 @@
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.tvmoview.domain.model.MediaItem
+import com.example.tvmoview.presentation.viewmodels.TileSize
 
 @Composable
 fun ModernTileView(
     items: List<MediaItem>,
     columnCount: Int,
+    tileSize: TileSize,
     state: LazyGridState,
     onItemClick: (MediaItem) -> Unit
 ) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(columnCount),
         state = state,
-        contentPadding = PaddingValues(0.dp),
-        horizontalArrangement = Arrangement.spacedBy(0.dp),
-        verticalArrangement = Arrangement.spacedBy(0.dp)
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentWidth(Alignment.CenterHorizontally),
+        contentPadding = PaddingValues(horizontal = 24.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         itemsIndexed(items) { index, item ->
             // 表示優先度を設定
@@ -34,7 +40,9 @@ fun ModernTileView(
                 onClick = { onItemClick(item) },
                 loadPriority = priority,
                 // showName の条件は変更なし（既に正しい）
-                showName = item.isFolder || (!item.isVideo && !item.isImage)
+                showName = item.isFolder || (!item.isVideo && !item.isImage),
+                height = tileSize.height.dp,
+                aspectRatio = 16f / 9f
             )
         }
     }

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernTopBar.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernTopBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 // ViewMode import追加
 import com.example.tvmoview.presentation.viewmodels.ViewMode
 import com.example.tvmoview.presentation.viewmodels.SortOrder
+import com.example.tvmoview.presentation.viewmodels.TileSize
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -23,8 +24,10 @@ fun ModernTopBar(
     viewMode: ViewMode,
     sortOrder: SortOrder,
     tileColumns: Int,
+    tileSize: TileSize,
     onViewModeChange: () -> Unit,
     onTileColumnsChange: () -> Unit,
+    onTileSizeChange: () -> Unit,
     onSortClick: () -> Unit,
     onOrderToggle: () -> Unit,
     onRefreshClick: () -> Unit,
@@ -104,6 +107,15 @@ fun ModernTopBar(
             if (viewMode == ViewMode.TILE) {
                 IconButton(onClick = onTileColumnsChange) {
                     Text(tileColumns.toString())
+                }
+                IconButton(onClick = onTileSizeChange) {
+                    Text(
+                        when (tileSize) {
+                            TileSize.SMALL -> "S"
+                            TileSize.MEDIUM -> "M"
+                            TileSize.LARGE -> "L"
+                        }
+                    )
                 }
             }
 

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
@@ -46,6 +46,7 @@ fun ModernMediaBrowser(
     val sortBy by viewModel.sortBy.collectAsState()
     val sortOrder by viewModel.sortOrder.collectAsState()
     val tileColumns by viewModel.tileColumns.collectAsState()
+    val tileSize by viewModel.tileSize.collectAsState()
     val currentPath by viewModel.currentPath.collectAsState()
     val currentFolder by viewModel.currentFolderId.collectAsState()
     val lastIndex by viewModel.lastIndex.collectAsState()
@@ -86,8 +87,10 @@ fun ModernMediaBrowser(
                 viewMode = viewMode,
                 sortOrder = sortOrder,
                 tileColumns = tileColumns,
+                tileSize = tileSize,
                 onViewModeChange = { viewModel.toggleViewMode() },
                 onTileColumnsChange = { viewModel.cycleTileColumns() },
+                onTileSizeChange = { viewModel.cycleTileSize() },
                 onSortClick = { showSortDialog = true },
                 onOrderToggle = { viewModel.setSortOrder(if (sortOrder == SortOrder.ASC) SortOrder.DESC else SortOrder.ASC) },
                 onRefreshClick = { viewModel.refresh() },
@@ -111,6 +114,7 @@ fun ModernMediaBrowser(
                                 ModernTileView(
                                     items = items,
                                     columnCount = tileColumns,
+                                    tileSize = tileSize,
                                     state = gridState,
                                     onItemClick = { item ->
                                         if (item.isFolder) {

--- a/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
@@ -25,6 +25,20 @@ enum class SortOrder {
     ASC, DESC
 }
 
+enum class TileSize(val height: Int) {
+    SMALL(135),
+    MEDIUM(180),
+    LARGE(240);
+
+    companion object {
+        fun fromHeight(value: Int) = when (value) {
+            135 -> SMALL
+            240 -> LARGE
+            else -> MEDIUM
+        }
+    }
+}
+
 class MediaBrowserViewModel : ViewModel() {
 
     private val _items = MutableStateFlow<List<MediaItem>>(emptyList())
@@ -44,6 +58,9 @@ class MediaBrowserViewModel : ViewModel() {
 
     private val _tileColumns = MutableStateFlow(UserPreferences.tileColumns)
     val tileColumns: StateFlow<Int> = _tileColumns.asStateFlow()
+
+    private val _tileSize = MutableStateFlow(TileSize.fromHeight(UserPreferences.tileHeight))
+    val tileSize: StateFlow<TileSize> = _tileSize.asStateFlow()
 
     private val _currentPath = MutableStateFlow("OneDrive")
     val currentPath: StateFlow<String> = _currentPath.asStateFlow()
@@ -164,6 +181,16 @@ class MediaBrowserViewModel : ViewModel() {
         }
         _tileColumns.value = next
         UserPreferences.tileColumns = next
+    }
+
+    fun cycleTileSize() {
+        val next = when (_tileSize.value) {
+            TileSize.SMALL -> TileSize.MEDIUM
+            TileSize.MEDIUM -> TileSize.LARGE
+            TileSize.LARGE -> TileSize.SMALL
+        }
+        _tileSize.value = next
+        UserPreferences.tileHeight = next.height
     }
 
     fun setSortBy(sortBy: SortBy) {


### PR DESCRIPTION
## Summary
- add tile height preference
- support TileSize enum in view model
- expose tile size controls in top bar
- update ModernTileView to centralize grid and size cards
- adapt ModernMediaCard to 16:9 tiles with rounded corners

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68654b9b72bc832cb1d245d8d9f67a81