### PR TITLE
Switch LazyRow to TvLazyRow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,8 +76,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 
     // TV Support
-    implementation("androidx.tv:tv-foundation:1.0.0-alpha10")
-    implementation("androidx.tv:tv-material:1.0.0-alpha10")
+    implementation("androidx.tv:tv-foundation:1.0.0-beta01")
+    implementation("androidx.tv:tv-material:1.0.0-beta01")
     implementation("androidx.leanback:leanback:1.0.0")
 
     // ✅ Media3 ExoPlayer（動画再生強化）

--- a/app/src/main/java/com/example/tvmoview/presentation/components/HuluStyleView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HuluStyleView.kt
@@ -3,9 +3,9 @@ package com.example.tvmoview.presentation.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.tv.foundation.lazy.list.TvLazyRow
+import androidx.tv.foundation.lazy.list.items
+import androidx.tv.foundation.lazy.list.rememberTvLazyListState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.runtime.Composable
@@ -63,8 +63,8 @@ fun HuluStyleView(
                 )
             }
             item(key = "${group.date}_content") {
-                val listState = rememberLazyListState()
-                LazyRow(
+                val listState = rememberTvLazyListState()
+                TvLazyRow(
                     state = listState,
                     contentPadding = PaddingValues(horizontal = 24.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp),


### PR DESCRIPTION
## Summary
- use `TvLazyRow` instead of `LazyRow`
- add `rememberTvLazyListState`
- update tv foundation dependency to beta

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68663be13ed4832c9d0a8a0aede6b00a