### PR TITLE
Fix Compose TV alpha12 compatibility

### DIFF
--- a/app/src/main/java/com/example/tvmoview/presentation/components/HuluStyleView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HuluStyleView.kt
@@ -3,9 +3,11 @@ package com.example.tvmoview.presentation.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.tv.foundation.lazy.list.TvLazyRow
-import androidx.tv.foundation.lazy.list.items
-import androidx.tv.foundation.lazy.list.rememberTvLazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.animateItemPlacement
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.runtime.Composable
@@ -63,12 +65,14 @@ fun HuluStyleView(
                 )
             }
             item(key = "${group.date}_content") {
-                val listState = rememberTvLazyListState()
-                TvLazyRow(
+                val listState = rememberLazyListState()
+                LazyRow(
                     state = listState,
                     contentPadding = PaddingValues(horizontal = 24.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    modifier = Modifier.padding(bottom = 16.dp)
+                    modifier = Modifier
+                        .padding(bottom = 16.dp)
+                        .focusRestorer()
                 ) {
                     items(
                         items = group.items,

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernTileView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernTileView.kt
@@ -1,10 +1,11 @@
 ﻿package com.example.tvmoview.presentation.components
 
 import androidx.compose.foundation.layout.*
-import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
-import androidx.tv.foundation.lazy.grid.TvGridCells
-import androidx.tv.foundation.lazy.grid.TvLazyGridState
-import androidx.tv.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -14,15 +15,16 @@ import com.example.tvmoview.domain.model.MediaItem
 fun ModernTileView(
     items: List<MediaItem>,
     columnCount: Int,
-    state: TvLazyGridState,
+    state: LazyGridState,
     onItemClick: (MediaItem) -> Unit
 ) {
-    TvLazyVerticalGrid(
-        columns = TvGridCells.Fixed(columnCount),
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(columnCount),
         state = state,
         contentPadding = PaddingValues(0.dp),
         horizontalArrangement = Arrangement.spacedBy(0.dp),
-        verticalArrangement = Arrangement.spacedBy(0.dp)
+        verticalArrangement = Arrangement.spacedBy(0.dp),
+        modifier = Modifier.focusRestorer()
     ) {
         itemsIndexed(
             items = items,

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
@@ -11,8 +11,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.alpha
-import androidx.tv.foundation.lazy.grid.TvLazyGridState
-import androidx.tv.foundation.lazy.grid.rememberTvLazyGridState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -52,7 +52,7 @@ fun ModernMediaBrowser(
     val lastIndex by viewModel.lastIndex.collectAsState()
 
     var showSortDialog by remember { mutableStateOf(false) }
-    val gridState = rememberTvLazyGridState(initialFirstVisibleItemIndex = lastIndex)
+    val gridState = rememberLazyGridState(initialFirstVisibleItemIndex = lastIndex)
     val coroutineScope = rememberCoroutineScope()
 
     DisposableEffect(Unit) {


### PR DESCRIPTION
## Summary
- update code to use standard Compose lazy components
- ensure tv-foundation remains on 1.0.0-alpha12

## Testing
- `./gradlew help` *(fails: unable to download due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866f6c78f1c832cb3860c985978da4a