### PR TITLE
Update TV libraries and focus behavior

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,8 +76,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 
     // TV Support
-    implementation("androidx.tv:tv-foundation:1.0.0-alpha10")
-    implementation("androidx.tv:tv-material:1.0.0-alpha10")
+    implementation("androidx.tv:tv-foundation:1.0.0-alpha12")
+    implementation("androidx.tv:tv-material:1.0.0")
     implementation("androidx.leanback:leanback:1.0.0")
 
     // ✅ Media3 ExoPlayer（動画再生強化）

--- a/app/src/main/java/com/example/tvmoview/presentation/components/HuluStyleView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HuluStyleView.kt
@@ -4,7 +4,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -51,15 +55,21 @@ fun HuluStyleView(
                 )
             }
             item(key = "${group.date}_content") {
+                val rowState = rememberLazyListState()
+                val rowFocusRequester = remember { FocusRequester() }
                 LazyRow(
+                    state = rowState,
                     contentPadding = PaddingValues(horizontal = 24.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    modifier = Modifier.padding(bottom = 16.dp)
+                    modifier = Modifier
+                        .padding(bottom = 16.dp)
+                        .focusRestorer(rowFocusRequester)
                 ) {
-                    items(items = group.items, key = { it.id }) { item ->
+                    itemsIndexed(items = group.items, key = { _, it -> it.id }) { index, item ->
                         HuluMediaCard(
                             item = item,
-                            onClick = { onItemClick(item) }
+                            onClick = { onItemClick(item) },
+                            modifier = if (index == 0) Modifier.focusRequester(rowFocusRequester) else Modifier
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
- bump tv-foundation to `1.0.0-alpha12`
- bump tv-material to `1.0.0`
- enhance `HuluStyleView` LazyRow with focusRestorer and focusRequester

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686716802d44832cbbae724d0307b210