### PR TITLE
Update splash screen and icons

### DIFF
--- a/app/src/main/java/com/example/tvmoview/MainActivity.kt
+++ b/app/src/main/java/com/example/tvmoview/MainActivity.kt
@@ -151,7 +151,7 @@ fun AuthenticationWrapper() {
     }
 
     when (authState) {
-        AuthState.Checking -> SplashScreen()
+        AuthState.Checking -> SplashScreen(onFinished = {})
 
         AuthState.Authenticated -> {
             AppNavigation()

--- a/app/src/main/java/com/example/tvmoview/MainActivity.kt
+++ b/app/src/main/java/com/example/tvmoview/MainActivity.kt
@@ -105,8 +105,14 @@ class MainActivity : ComponentActivity() {
         Log.d("MainActivity", "📁 OneDrive統合準備完了")
 
         setContent {
+            var showSplash by remember { mutableStateOf(true) }
+
             TVMovieTheme {
-                AuthenticationWrapper()
+                if (showSplash) {
+                    SplashScreen(onFinished = { showSplash = false })
+                } else {
+                    AuthenticationWrapper()
+                }
             }
         }
 

--- a/app/src/main/java/com/example/tvmoview/presentation/components/EmptyStateView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/EmptyStateView.kt
@@ -1,6 +1,7 @@
 ﻿package com.example.tvmoview.presentation.components
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.Image
 import androidx.compose.material3.*
 import androidx.compose.ui.res.painterResource
 import com.example.tvmoview.R
@@ -16,11 +17,10 @@ fun EmptyStateView() {
         contentAlignment = Alignment.Center
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(
+            Image(
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
-                modifier = Modifier.size(64.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                modifier = Modifier.size(64.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(

--- a/app/src/main/java/com/example/tvmoview/presentation/components/EmptyStateView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/EmptyStateView.kt
@@ -20,7 +20,7 @@ fun EmptyStateView() {
             Image(
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
-                modifier = Modifier.size(64.dp)
+                modifier = Modifier.size(128.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(

--- a/app/src/main/java/com/example/tvmoview/presentation/components/EmptyStateView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/EmptyStateView.kt
@@ -1,9 +1,9 @@
 ﻿package com.example.tvmoview.presentation.components
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material3.*
+import androidx.compose.ui.res.painterResource
+import com.example.tvmoview.R
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,7 +17,7 @@ fun EmptyStateView() {
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(
-                Icons.Default.FolderOpen,
+                painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
                 modifier = Modifier.size(64.dp),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/com/example/tvmoview/presentation/components/HuluMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HuluMediaCard.kt
@@ -159,7 +159,7 @@ private fun MediaOverlay(item: MediaItem) {
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
                 modifier = Modifier
-                    .size(48.dp)
+                    .size(96.dp)
                     .align(Alignment.Center)
             )
         }

--- a/app/src/main/java/com/example/tvmoview/presentation/components/HuluMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HuluMediaCard.kt
@@ -6,8 +6,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -29,6 +27,8 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.shadow
 import com.example.tvmoview.domain.model.MediaItem
 import com.example.tvmoview.presentation.theme.HuluColors
+import androidx.compose.ui.res.painterResource
+import com.example.tvmoview.R
 
 @Composable
 fun HuluMediaCard(
@@ -155,7 +155,7 @@ private fun MediaOverlay(item: MediaItem) {
         }
         if (item.isFolder) {
             androidx.compose.material3.Icon(
-                imageVector = Icons.Default.Folder,
+                painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
                 tint = Color.White.copy(alpha = 0.8f),
                 modifier = Modifier

--- a/app/src/main/java/com/example/tvmoview/presentation/components/HuluMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HuluMediaCard.kt
@@ -29,6 +29,7 @@ import com.example.tvmoview.domain.model.MediaItem
 import com.example.tvmoview.presentation.theme.HuluColors
 import androidx.compose.ui.res.painterResource
 import com.example.tvmoview.R
+import androidx.compose.foundation.Image
 
 @Composable
 fun HuluMediaCard(
@@ -154,10 +155,9 @@ private fun MediaOverlay(item: MediaItem) {
             )
         }
         if (item.isFolder) {
-            androidx.compose.material3.Icon(
+            Image(
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
-                tint = Color.White.copy(alpha = 0.8f),
                 modifier = Modifier
                     .size(48.dp)
                     .align(Alignment.Center)

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
@@ -17,10 +17,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.painterResource
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import coil.request.CachePolicy
 import com.example.tvmoview.domain.model.MediaItem
+import com.example.tvmoview.R
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -112,7 +114,7 @@ fun ModernMediaCard(
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Folder,
+                            painter = painterResource(R.drawable.folder_icon),
                             contentDescription = null,
                             modifier = Modifier.size(48.dp),
                             tint = MaterialTheme.colorScheme.primary

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.painterResource
+import androidx.compose.foundation.Image
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import coil.request.CachePolicy
@@ -113,11 +114,10 @@ fun ModernMediaCard(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
                     ) {
-                        Icon(
+                        Image(
                             painter = painterResource(R.drawable.folder_icon),
                             contentDescription = null,
-                            modifier = Modifier.size(48.dp),
-                            tint = MaterialTheme.colorScheme.primary
+                            modifier = Modifier.size(48.dp)
                         )
                     }
                 }

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
@@ -117,7 +117,7 @@ fun ModernMediaCard(
                         Image(
                             painter = painterResource(R.drawable.folder_icon),
                             contentDescription = null,
-                            modifier = Modifier.size(48.dp)
+                            modifier = Modifier.size(96.dp)
                         )
                     }
                 }

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.painterResource
+import androidx.compose.foundation.Image
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalDensity
@@ -252,11 +253,10 @@ fun EmptyStateView() {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Icon(
+            Image(
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
-                modifier = Modifier.size(64.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                modifier = Modifier.size(64.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
@@ -15,9 +15,11 @@ import androidx.compose.foundation.lazy.grid.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalDensity
+import com.example.tvmoview.R
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.tvmoview.MainActivity
 import com.example.tvmoview.domain.model.*
@@ -251,7 +253,7 @@ fun EmptyStateView() {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Icon(
-                imageVector = Icons.Default.FolderOpen,
+                painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
                 modifier = Modifier.size(64.dp),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
@@ -256,7 +256,7 @@ fun EmptyStateView() {
             Image(
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
-                modifier = Modifier.size(64.dp)
+                modifier = Modifier.size(128.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/SplashScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/SplashScreen.kt
@@ -59,7 +59,7 @@ fun SplashScreen(
             painter = painterResource(id = R.drawable.app_logo),
             contentDescription = "App Logo",
             modifier = Modifier
-                .size(160.dp)
+                .size(400.dp)
                 .graphicsLayer {
                     this.alpha = alpha
                     this.scaleX = scale

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/SplashScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/SplashScreen.kt
@@ -1,42 +1,73 @@
 package com.example.tvmoview.presentation.screens
 
-import androidx.annotation.DrawableRes
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.RoundedCornerShape
 import com.example.tvmoview.R
+import kotlinx.coroutines.delay
 
 @Composable
-fun SplashScreen(@DrawableRes logoRes: Int = R.drawable.app_banner) {
+fun SplashScreen(
+    onFinished: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var startAnimation by remember { mutableStateOf(false) }
+
+    val alpha by animateFloatAsState(
+        targetValue = if (startAnimation) 1f else 0f,
+        animationSpec = tween(durationMillis = 1200, easing = FastOutSlowInEasing),
+        label = "alpha"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (startAnimation) 1f else 1.1f,
+        animationSpec = tween(durationMillis = 1200, easing = FastOutSlowInEasing),
+        label = "scale"
+    )
+
+    LaunchedEffect(Unit) {
+        startAnimation = true
+        delay(2000)
+        onFinished()
+    }
+
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(
-                Brush.verticalGradient(
-                    listOf(
-                        MaterialTheme.colorScheme.primaryContainer,
-                        MaterialTheme.colorScheme.surface
-                    )
+                brush = Brush.verticalGradient(
+                    colors = listOf(Color(0xFF0A0A0A), Color(0xFF1A1A1A))
                 )
             ),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Image(
-                painter = painterResource(logoRes),
-                contentDescription = null,
-                modifier = Modifier.size(180.dp)
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            CircularProgressIndicator()
-        }
+        Image(
+            painter = painterResource(id = R.drawable.app_logo),
+            contentDescription = "App Logo",
+            modifier = Modifier
+                .size(160.dp)
+                .graphicsLayer {
+                    this.alpha = alpha
+                    this.scaleX = scale
+                    this.scaleY = scale
+                    this.shadowElevation = 12f
+                    this.shape = RoundedCornerShape(24.dp)
+                    this.clip = true
+                }
+        )
     }
 }


### PR DESCRIPTION
## Summary
- redesign splash screen with fade/scale animation
- delay splash for 2 seconds before showing main content
- replace all folder icons with `folder_icon.png`

## Testing
- `./gradlew test` *(fails: Unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68691ca3dfb8832c910e012295e7c647