### PR TITLE
Adjust tile card spacing

### DIFF
--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
@@ -36,7 +36,8 @@ fun ModernMediaCard(
             .fillMaxWidth()
             .aspectRatio(1f)
             .clickable { onClick() },
-        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(0.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {  // ColumnからBoxに変更
             // サムネイル/アイコン表示部分

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernTileView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernTileView.kt
@@ -17,9 +17,9 @@ fun ModernTileView(
     LazyVerticalGrid(
         columns = GridCells.Fixed(columnCount),
         state = state,
-        contentPadding = PaddingValues(0.dp),
-        horizontalArrangement = Arrangement.spacedBy(0.dp),
-        verticalArrangement = Arrangement.spacedBy(0.dp)
+        contentPadding = PaddingValues(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         itemsIndexed(items) { index, item ->
             // 表示優先度を設定


### PR DESCRIPTION
## Summary
- space out tiles slightly for readability
- remove rounded corners from tile cards

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68692c65e844832c9c60b67b7242c0aa