### PR TITLE
Optimize image loading and caching

### DIFF
--- a/app/src/main/java/com/example/tvmoview/MainActivity.kt
+++ b/app/src/main/java/com/example/tvmoview/MainActivity.kt
@@ -64,12 +64,13 @@ class MainActivity : ComponentActivity() {
             .diskCache(
                 DiskCache.Builder()
                     .directory(cacheDir.resolve("image_cache"))
-                    .maxSizeBytes(50L * 1024 * 1024) // 50MB
+                    .maxSizeBytes(30L * 1024 * 1024) // 30MB
                     .build()
             )
             .memoryCache(
                 MemoryCache.Builder(this)
-                    .maxSizePercent(0.15)
+                    .maxSizePercent(0.08)
+                    .weakReferencesEnabled(true)
                     .build()
             )
             .okHttpClient {

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
@@ -71,7 +71,7 @@ fun ModernMediaCard(
                                     .background(
                                         shimmerBrush(
                                             targetValue = 1300f,
-                                            showShimmer = true
+                                            showShimmer = false
                                         )
                                     )
                             )
@@ -185,7 +185,7 @@ private fun generateVideoThumbnail(item: MediaItem): String? {
 
 // シマーエフェクト用ブラシ
 @Composable
-fun shimmerBrush(targetValue: Float = 1000f, showShimmer: Boolean = true): Brush {
+fun shimmerBrush(targetValue: Float = 1000f, showShimmer: Boolean = false): Brush {
     return if (showShimmer) {
         val shimmerColors = listOf(
             Color.LightGray.copy(alpha = 0.6f),
@@ -210,7 +210,10 @@ fun shimmerBrush(targetValue: Float = 1000f, showShimmer: Boolean = true): Brush
         )
     } else {
         Brush.linearGradient(
-            colors = listOf(Color.Transparent, Color.Transparent),
+            colors = listOf(
+                Color.LightGray.copy(alpha = 0.3f),
+                Color.LightGray.copy(alpha = 0.3f)
+            ),
             start = Offset.Zero,
             end = Offset.Zero
         )

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernTileView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernTileView.kt
@@ -2,6 +2,7 @@
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.*
+import androidx.compose.foundation.lazy.layout.LazyLayoutPrefetchPolicy
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -26,13 +27,16 @@ fun ModernTileView(
         modifier = Modifier.focusRequester(focusRequester),
         contentPadding = PaddingValues(4.dp),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp)
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        prefetchPolicy = LazyLayoutPrefetchPolicy(initialPrefetchItemsCount = 6),
+        userScrollEnabled = true,
+        beyondBoundsLayout = null
     ) {
         itemsIndexed(items) { index, item ->
             // 表示優先度を設定
             val priority = when {
-                index < 10 -> 1.0f  // 最初の10個は最優先
-                index < 30 -> 0.5f  // 次の20個は中優先度
+                index < 6 -> 1.0f  // 最初の6個は最優先
+                index < 18 -> 0.5f  // 次の12個は中優先度
                 else -> 0.1f        // それ以降は低優先度
             }
 

--- a/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
@@ -231,22 +231,22 @@ class MediaBrowserViewModel : ViewModel() {
     private fun displayItemsProgressive(allItems: List<MediaItem>) {
         val sorted = applySorting(allItems)
         when {
-            sorted.size <= 10 -> {
+            sorted.size <= 8 -> {
                 _items.value = sorted
             }
-            sorted.size <= 30 -> {
-                _items.value = sorted.take(10)
+            sorted.size <= 24 -> {
+                _items.value = sorted.take(8)
                 viewModelScope.launch {
-                    kotlinx.coroutines.delay(100)
+                    kotlinx.coroutines.delay(150)
                     _items.value = sorted
                 }
             }
             else -> {
-                _items.value = sorted.take(10)
+                _items.value = sorted.take(8)
                 viewModelScope.launch {
-                    kotlinx.coroutines.delay(100)
-                    _items.value = sorted.take(30)
-                    kotlinx.coroutines.delay(300)
+                    kotlinx.coroutines.delay(150)
+                    _items.value = sorted.take(24)
+                    kotlinx.coroutines.delay(400)
                     _items.value = sorted
                 }
             }


### PR DESCRIPTION
## Summary
- tighten Coil cache usage
- simplify shimmer effect and disable by default
- limit lazy grid prefetch and adjust priority windows
- reduce chunk sizes for progressive list updates

## Testing
- `./gradlew test --daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686aaf0bae40832c9e461a7d36ea3c38