### PR TITLE
Fix ExoPlayer cleanup and adjust UI sizes

### DIFF
--- a/app/src/main/java/com/example/tvmoview/presentation/components/EmptyStateView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/EmptyStateView.kt
@@ -20,7 +20,7 @@ fun EmptyStateView() {
             Image(
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
-                modifier = Modifier.size(128.dp)
+                modifier = Modifier.size(102.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(

--- a/app/src/main/java/com/example/tvmoview/presentation/components/HuluMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HuluMediaCard.kt
@@ -159,7 +159,7 @@ private fun MediaOverlay(item: MediaItem) {
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
                 modifier = Modifier
-                    .size(96.dp)
+                    .size(76.dp)
                     .align(Alignment.Center)
             )
         }

--- a/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/ModernMediaCard.kt
@@ -115,7 +115,7 @@ fun ModernMediaCard(
                         Image(
                             painter = painterResource(R.drawable.folder_icon),
                             contentDescription = null,
-                            modifier = Modifier.size(96.dp)
+                            modifier = Modifier.size(76.dp)
                         )
                     }
                 }

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
@@ -60,6 +60,7 @@ fun HighQualityPlayerScreen(
     // ExoPlayer初期化
     var exoPlayer by remember { mutableStateOf<ExoPlayer?>(null) }
     LaunchedEffect(resolvedUrl) {
+        releasePlayer()
         exoPlayer = resolvedUrl?.let { url ->
             ExoPlayer.Builder(context).build().also { player ->
                 Log.d("VideoPlayer", "📺 動画URL設定: $url")
@@ -74,6 +75,10 @@ fun HighQualityPlayerScreen(
                 player.playWhenReady = true
             }
         }
+        playerView?.player = exoPlayer
+    }
+    LaunchedEffect(playerView, exoPlayer) {
+        playerView?.player = exoPlayer
     }
 
     // カスタムシークバー表示コルーチン
@@ -97,6 +102,7 @@ fun HighQualityPlayerScreen(
         exoPlayer?.pause()
         exoPlayer?.release()
         exoPlayer = null
+        playerView?.player = null
     }
 
     // 再生位置更新ループ

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
@@ -59,6 +59,14 @@ fun HighQualityPlayerScreen(
 
     // ExoPlayer初期化
     var exoPlayer by remember { mutableStateOf<ExoPlayer?>(null) }
+
+    fun releasePlayer() {
+        exoPlayer?.pause()
+        exoPlayer?.release()
+        exoPlayer = null
+        playerView?.player = null
+    }
+
     LaunchedEffect(resolvedUrl) {
         releasePlayer()
         exoPlayer = resolvedUrl?.let { url ->
@@ -96,13 +104,6 @@ fun HighQualityPlayerScreen(
             delay(durationMillis)
             showCustomSeek = false
         }
-    }
-
-    fun releasePlayer() {
-        exoPlayer?.pause()
-        exoPlayer?.release()
-        exoPlayer = null
-        playerView?.player = null
     }
 
     // 再生位置更新ループ

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
@@ -270,7 +270,7 @@ fun EmptyStateView() {
             Image(
                 painter = painterResource(R.drawable.folder_icon),
                 contentDescription = null,
-                modifier = Modifier.size(128.dp)
+                modifier = Modifier.size(102.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/SplashScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/SplashScreen.kt
@@ -59,13 +59,13 @@ fun SplashScreen(
             painter = painterResource(id = R.drawable.app_logo),
             contentDescription = "App Logo",
             modifier = Modifier
-                .size(400.dp)
+                .size(200.dp)
                 .graphicsLayer {
                     this.alpha = alpha
                     this.scaleX = scale
                     this.scaleY = scale
                     this.shadowElevation = 12f
-                    this.shape = RoundedCornerShape(24.dp)
+                    this.shape = RoundedCornerShape(16.dp)
                     this.clip = true
                 }
         )


### PR DESCRIPTION
## Summary
- stop playback properly when leaving HighQualityPlayerScreen
- round the splash logo and shrink it to half size
- make folder icons smaller

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686aba5b2298832ca94d59e78fdcb0a9