### PR TITLE
Fix seek preview update

### DIFF
--- a/app/src/main/java/com/example/tvmoview/presentation/components/SeekPreview.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/SeekPreview.kt
@@ -29,6 +29,10 @@ fun SeekPreview(
         onDispose { previewPlayer?.release() }
     }
 
+    LaunchedEffect(seekPosition) {
+        previewPlayer?.seekTo(seekPosition)
+    }
+
     AndroidView(
         factory = { PlayerView(it).apply {
             player = previewPlayer


### PR DESCRIPTION
## Summary
- update SeekPreview so that the preview player moves when the seek position changes

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686c5b800f30832cac970e2ce8bc9b93