### PR TITLE
Add logging for seek preview debugging

### DIFF
--- a/app/src/main/java/com/example/tvmoview/presentation/components/UltraFastSeekPreview.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/UltraFastSeekPreview.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import android.util.Log
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,10 +27,18 @@ fun UltraFastSeekPreview(
     intervalMs: Long = 10_000L
 ) {
     val thumb by produceState<android.graphics.Bitmap?>(null, videoUrl, seekPosition) {
+        Log.d("SeekPreview", "🔍 request frame @${seekPosition}ms")
         UltraFastThumbnailExtractor.prewarm(videoUrl, intervalMs)
+        var loggedWait = false
         while (value == null) {
             value = UltraFastThumbnailExtractor.get(videoUrl, seekPosition, intervalMs)
-            if (value == null) delay(40)
+            if (value == null) {
+                if (!loggedWait) Log.d("SeekPreview", "⏳ waiting for frame")
+                loggedWait = true
+                delay(40)
+            } else {
+                Log.d("SeekPreview", "✅ frame ready")
+            }
         }
     }
 

--- a/app/src/main/java/com/example/tvmoview/thumbnail/UltraFastThumbnailExtractor.kt
+++ b/app/src/main/java/com/example/tvmoview/thumbnail/UltraFastThumbnailExtractor.kt
@@ -6,6 +6,7 @@ import android.media.ImageReader
 import android.media.MediaCodec
 import android.media.MediaExtractor
 import android.media.MediaFormat
+import android.util.Log
 import androidx.annotation.WorkerThread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,9 +32,14 @@ object UltraFastThumbnailExtractor {
         maxW: Int = 300,
         maxH: Int = 180
     ) {
-        if (cache.keys.any { it.first == source }) return
+        if (cache.keys.any { it.first == source }) {
+            Log.d("ThumbnailExtractor", "🔄 cache already prepared: $source")
+            return
+        }
+        Log.d("ThumbnailExtractor", "🚀 prewarm start: $source")
         scope.launch {
             runCatching { decodeAll(source, intervalMs, maxW, maxH) }
+                .onFailure { Log.e("ThumbnailExtractor", "❌ prewarm error", it) }
         }
     }
 
@@ -41,10 +47,18 @@ object UltraFastThumbnailExtractor {
      * Returns cached bitmap if available. Null until generated.
      */
     fun get(source: String, timeMs: Long, intervalMs: Long = 10_000L): Bitmap? =
-        cache[source to (timeMs / intervalMs).toInt()]
+        cache[source to (timeMs / intervalMs).toInt()].also { bmp ->
+            if (bmp == null) {
+                Log.d(
+                    "ThumbnailExtractor",
+                    "⏳ cache miss for $source@${timeMs / intervalMs}"
+                )
+            }
+        }
 
     @WorkerThread
     private fun decodeAll(source: String, intervalMs: Long, maxW: Int, maxH: Int) {
+        Log.d("ThumbnailExtractor", "🎞️ decoding start: $source")
         val extractor = MediaExtractor().apply { setDataSource(source) }
         val track = (0 until extractor.trackCount).first {
             extractor.getTrackFormat(it).getString(MediaFormat.KEY_MIME)!!.startsWith("video/")
@@ -61,6 +75,7 @@ object UltraFastThumbnailExtractor {
 
         var completed = false
 
+        var frames = 0
         codec.setCallback(object : MediaCodec.Callback() {
             private var nextSnapshotUs = 0L
             private var frameIndex = 0
@@ -84,6 +99,7 @@ object UltraFastThumbnailExtractor {
                 if (needSnap) {
                     grab(reader)?.let { bmp ->
                         cache[source to frameIndex] = bmp
+                        frames++
                     }
                     frameIndex++
                     nextSnapshotUs += intervalMs * 1_000L
@@ -102,6 +118,7 @@ object UltraFastThumbnailExtractor {
         codec.release()
         extractor.release()
         reader.close()
+        Log.d("ThumbnailExtractor", "✅ decoding complete: $source frames=$frames")
     }
 
     private fun grab(reader: ImageReader): Bitmap? {


### PR DESCRIPTION
## Summary
- improve `UltraFastThumbnailExtractor` with debug logs for cache status and decode progress
- log seek preview fetch attempts in `UltraFastSeekPreview`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686c90d73bbc832c89c84ec68958d998