### PR TITLE
Add logging for thumbnail debug

### DIFF
--- a/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
@@ -95,7 +95,7 @@ fun HighQualityPlayerScreen(
         releasePlayer()
         resolvedUrl?.let { url ->
             withContext(Dispatchers.Default) {
-                UltraFastThumbnailExtractor.prewarm(url)
+                UltraFastThumbnailExtractor.prewarm(url, intervalMs = 1_000L)
             }
         }
         exoPlayer = resolvedUrl?.let { url ->
@@ -347,7 +347,8 @@ fun HighQualityPlayerScreen(
                         UltraFastSeekPreview(
                             videoUrl = resolvedUrl!!,
                             seekPosition = previewPosition,
-                            modifier = Modifier.align(Alignment.CenterHorizontally)
+                            modifier = Modifier.align(Alignment.CenterHorizontally),
+                            intervalMs = 1_000L
                         )
                     } else {
                         Box(


### PR DESCRIPTION
## Summary
- add detailed output logging when decoding frames
- log image acquisition failures
- reduce snapshot interval to 1s for HighQualityPlayerScreen

## Testing
- `./gradlew assembleDebug` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ccc7ff408832c8ee2795c85260bcb