### PR TITLE
Integrate shared ExoPlayer for seamless playback

### DIFF
--- a/app/src/main/java/com/example/tvmoview/MainActivity.kt
+++ b/app/src/main/java/com/example/tvmoview/MainActivity.kt
@@ -20,6 +20,8 @@ import androidx.navigation.navArgument
 import com.example.tvmoview.data.repository.MediaRepository
 import com.example.tvmoview.presentation.screens.*
 import com.example.tvmoview.presentation.theme.TVMovieTheme
+import com.example.tvmoview.presentation.viewmodels.SharedExoPlayerViewModel
+import com.example.tvmoview.presentation.viewmodels.ViewMode
 
 // OneDrive統合のための新しいimport
 import com.example.tvmoview.data.auth.AuthenticationManager
@@ -181,6 +183,7 @@ sealed class AuthState {
 @Composable
 fun AppNavigation() {
     val navController = rememberNavController()
+    val sharedPlayerViewModel: SharedExoPlayerViewModel = viewModel()
 
     NavHost(
         navController = navController,
@@ -189,6 +192,8 @@ fun AppNavigation() {
         // ホーム画面（メディア一覧）
         composable("home") {
             ModernMediaBrowser(
+                viewMode = ViewMode.HOME_VIDEO,
+                sharedPlayerViewModel = sharedPlayerViewModel,
                 onMediaSelected = { mediaItem ->
                     if (mediaItem.isVideo) {
                         Log.d("MainActivity", "🎬 動画選択: ${mediaItem.name}")
@@ -215,6 +220,7 @@ fun AppNavigation() {
             val folderId = backStackEntry.arguments?.getString("folderId") ?: ""
             ModernMediaBrowser(
                 folderId = folderId,
+                sharedPlayerViewModel = sharedPlayerViewModel,
                 onMediaSelected = { mediaItem ->
                     if (mediaItem.isVideo) {
                         Log.d("MainActivity", "🎬 フォルダ内動画選択: ${mediaItem.name}")
@@ -245,6 +251,7 @@ fun AppNavigation() {
 
             HighQualityPlayerScreen(
                 itemId = itemId,
+                sharedPlayerViewModel = sharedPlayerViewModel,
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/com/example/tvmoview/presentation/components/VideoTransitionWrapper.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/VideoTransitionWrapper.kt
@@ -1,0 +1,40 @@
+package com.example.tvmoview.presentation.components
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.foundation.layout.Box
+
+@Composable
+fun VideoTransitionWrapper(
+    isFullScreen: Boolean,
+    content: @Composable () -> Unit
+) {
+    val transition = updateTransition(targetState = isFullScreen, label = "video_transition")
+
+    val scale by transition.animateFloat(
+        transitionSpec = {
+            spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow)
+        }, label = "scale"
+    ) { full -> if (full) 1f else 0.8f }
+
+    val alpha by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 300) }, label = "alpha"
+    ) { if (it) 1f else 0.95f }
+
+    Box(
+        modifier = Modifier.graphicsLayer {
+            scaleX = scale
+            scaleY = scale
+            this.alpha = alpha
+        }
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/example/tvmoview/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/navigation/AppNavigation.kt
@@ -7,10 +7,13 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.example.tvmoview.presentation.screens.*
+import com.example.tvmoview.presentation.viewmodels.SharedExoPlayerViewModel
+import com.example.tvmoview.presentation.viewmodels.ViewMode
 
 @Composable
 fun AppNavigation() {
     val navController = rememberNavController()
+    val sharedPlayerViewModel: SharedExoPlayerViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
 
     NavHost(
         navController = navController,
@@ -20,6 +23,8 @@ fun AppNavigation() {
         composable("home") {
             ModernMediaBrowser(
                 folderId = null,
+                viewMode = ViewMode.HOME_VIDEO,
+                sharedPlayerViewModel = sharedPlayerViewModel,
                 onMediaSelected = { mediaItem ->
                     if (mediaItem.isVideo) {
                         navController.navigate("player/${mediaItem.id}")
@@ -45,6 +50,7 @@ fun AppNavigation() {
 
             ModernMediaBrowser(
                 folderId = folderId,
+                sharedPlayerViewModel = sharedPlayerViewModel,
                 onMediaSelected = { mediaItem ->
                     if (mediaItem.isVideo) {
                         navController.navigate("player/${mediaItem.id}")
@@ -72,6 +78,7 @@ fun AppNavigation() {
             val itemId = backStackEntry.arguments?.getString("itemId") ?: ""
             HighQualityPlayerScreen(
                 itemId = itemId,
+                sharedPlayerViewModel = sharedPlayerViewModel,
                 onBack = {
                     navController.popBackStack()
                 }
@@ -86,5 +93,4 @@ fun AppNavigation() {
                 }
             )
         }
-    }
-}
+    }}

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/ModernMediaBrowser.kt
@@ -29,6 +29,7 @@ import com.example.tvmoview.presentation.viewmodels.MediaBrowserViewModel
 import com.example.tvmoview.presentation.viewmodels.ViewMode
 import com.example.tvmoview.presentation.viewmodels.SortBy
 import com.example.tvmoview.presentation.viewmodels.SortOrder
+import com.example.tvmoview.presentation.viewmodels.SharedExoPlayerViewModel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import java.text.SimpleDateFormat
@@ -38,6 +39,8 @@ import java.util.Locale
 @Composable
 fun ModernMediaBrowser(
     folderId: String? = null,
+    viewMode: ViewMode = ViewMode.TILE,
+    sharedPlayerViewModel: SharedExoPlayerViewModel? = null,
     onMediaSelected: (MediaItem) -> Unit,
     onFolderSelected: (String) -> Unit,
     onSettingsClick: (() -> Unit)? = null,
@@ -46,7 +49,7 @@ fun ModernMediaBrowser(
     val viewModel: MediaBrowserViewModel = viewModel()
     val items by viewModel.items.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
-    val viewMode by viewModel.viewMode.collectAsState()
+    val viewModeState by viewModel.viewMode.collectAsState(initial = viewMode)
     val sortBy by viewModel.sortBy.collectAsState()
     val sortOrder by viewModel.sortOrder.collectAsState()
     val tileColumns by viewModel.tileColumns.collectAsState()
@@ -97,7 +100,7 @@ fun ModernMediaBrowser(
             ) {
                 ModernTopBar(
                     currentPath = currentPath,
-                    viewMode = viewMode,
+                    viewMode = viewModeState,
                     sortOrder = sortOrder,
                     tileColumns = tileColumns,
                     onViewModeChange = { viewModel.toggleViewMode() },
@@ -121,7 +124,7 @@ fun ModernMediaBrowser(
 
                     // データがある場合は常にコンテンツ表示（手動更新中でも表示継続）
                     else -> {
-                        when (viewMode) {
+                        when (viewModeState) {
                             ViewMode.TILE -> {
                                 ModernTileView(
                                     items = items,
@@ -224,6 +227,7 @@ fun ModernMediaBrowser(
                             ViewMode.HOME_VIDEO -> {
                                 HomeVideoView(
                                     items = items,
+                                    sharedPlayerViewModel = sharedPlayerViewModel,
                                     onItemClick = { item ->
                                         if (item.isFolder) {
                                             onFolderSelected(item.id)

--- a/app/src/main/java/com/example/tvmoview/presentation/viewmodels/SharedExoPlayerViewModel.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/viewmodels/SharedExoPlayerViewModel.kt
@@ -1,0 +1,76 @@
+package com.example.tvmoview.presentation.viewmodels
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import kotlinx.coroutines.launch
+import com.example.tvmoview.domain.model.MediaItem as DomainMediaItem
+
+class SharedExoPlayerViewModel : ViewModel() {
+    private var exoPlayer: ExoPlayer? = null
+    private val _currentItem = MutableStateFlow<DomainMediaItem?>(null)
+    val currentItem: StateFlow<DomainMediaItem?> = _currentItem.asStateFlow()
+    private val _isFullScreen = MutableStateFlow(false)
+    val isFullScreen: StateFlow<Boolean> = _isFullScreen.asStateFlow()
+    private val _playbackPosition = MutableStateFlow(0L)
+    val playbackPosition: StateFlow<Long> = _playbackPosition.asStateFlow()
+
+    fun initializePlayer(context: Context): ExoPlayer {
+        if (exoPlayer == null) {
+            exoPlayer = ExoPlayer.Builder(context).build()
+        }
+        return exoPlayer!!
+    }
+
+    fun prepareVideo(item: DomainMediaItem, videoUrl: String) {
+        _currentItem.value = item
+        exoPlayer?.apply {
+            setMediaItem(MediaItem.fromUri(videoUrl))
+            prepare()
+        }
+    }
+
+    fun startPreview() {
+        _isFullScreen.value = false
+        exoPlayer?.apply {
+            volume = 0f
+            repeatMode = ExoPlayer.REPEAT_MODE_ONE
+            play()
+        }
+    }
+
+    fun transitionToFullScreen() {
+        _playbackPosition.value = exoPlayer?.currentPosition ?: 0L
+        _isFullScreen.value = true
+        exoPlayer?.apply {
+            volume = 1f
+            repeatMode = ExoPlayer.REPEAT_MODE_OFF
+        }
+    }
+
+    fun exitFullScreen() {
+        _playbackPosition.value = exoPlayer?.currentPosition ?: 0L
+        _isFullScreen.value = false
+        exoPlayer?.apply {
+            volume = 0f
+            repeatMode = ExoPlayer.REPEAT_MODE_ONE
+        }
+    }
+
+    fun releasePlayer() {
+        exoPlayer?.release()
+        exoPlayer = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        releasePlayer()
+    }
+
+    fun getPlayer(): ExoPlayer? = exoPlayer
+}


### PR DESCRIPTION
## Summary
- create `SharedExoPlayerViewModel` for reusing ExoPlayer
- update `HomeVideoView` to use shared player and hand off to fullscreen
- add `VideoTransitionWrapper` for simple scale/alpha effect
- refactor `HighQualityPlayerScreen` to use shared player and transition state
- pass shared player through `AppNavigation` and `MainActivity`
- wire `ModernMediaBrowser` to accept the shared model

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686d74a162b4832cb900e893c52e0e22