### PR TITLE
Add shared player for seamless preview transition

### DIFF
--- a/app/src/main/java/com/example/tvmoview/MainActivity.kt
+++ b/app/src/main/java/com/example/tvmoview/MainActivity.kt
@@ -198,6 +198,7 @@ fun AppNavigation() {
                 onMediaSelected = { mediaItem ->
                     if (mediaItem.isVideo) {
                         Log.d("MainActivity", "🎬 動画選択: ${mediaItem.name}")
+                        sharedViewModel.setFullscreenTransition(true)
                         navController.navigate("player/${mediaItem.id}")
                     } else if (mediaItem.isImage) {
                         Log.d("MainActivity", "🖼️ 画像選択: ${mediaItem.name}")
@@ -225,6 +226,7 @@ fun AppNavigation() {
                 onMediaSelected = { mediaItem ->
                     if (mediaItem.isVideo) {
                         Log.d("MainActivity", "🎬 フォルダ内動画選択: ${mediaItem.name}")
+                        sharedViewModel.setFullscreenTransition(true)
                         navController.navigate("player/${mediaItem.id}")
                     } else if (mediaItem.isImage) {
                         Log.d("MainActivity", "🖼️ フォルダ内画像選択: ${mediaItem.name}")

--- a/app/src/main/java/com/example/tvmoview/presentation/components/HomeVideoView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HomeVideoView.kt
@@ -148,11 +148,11 @@ private fun MainPreviewArea(
         showVideo = false
         videoUrl = null
         if (selectedMedia?.isVideo == true) {
-            // OneDriveからダウンロードURL取得
             val url = com.example.tvmoview.MainActivity.oneDriveRepository
                 .getDownloadUrl(selectedMedia.id)
             if (url != null) {
                 videoUrl = url
+                viewModel.setCurrentVideoUrl(url)
                 delay(500)
                 showVideo = true
             }

--- a/app/src/main/java/com/example/tvmoview/presentation/components/HomeVideoView.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/components/HomeVideoView.kt
@@ -279,6 +279,7 @@ private fun VideoPreview(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val isTransitioning by viewModel.isTransitioningToFullscreen.collectAsState()
     var currentPosition by remember { mutableLongStateOf(0L) }
     var showCover by remember { mutableStateOf(true) }
     var bufferProgress by remember { mutableFloatStateOf(0f) }
@@ -301,8 +302,7 @@ private fun VideoPreview(
         }
     }
 
-    DisposableEffect(viewModel.isTransitioningToFullscreen.collectAsState().value) {
-        val isTransitioning = viewModel.isTransitioningToFullscreen.collectAsState().value
+    DisposableEffect(isTransitioning) {
         val listener = object : Player.Listener {
             override fun onPlaybackStateChanged(state: Int) {
                 if (state == Player.STATE_READY) showCover = false

--- a/app/src/main/java/com/example/tvmoview/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/navigation/AppNavigation.kt
@@ -29,6 +29,7 @@ fun AppNavigation() {
                 folderId = null,
                 onMediaSelected = { mediaItem ->
                     if (mediaItem.isVideo) {
+                        sharedViewModel.setFullscreenTransition(true)
                         navController.navigate("player/${mediaItem.id}")
                     }
                 },
@@ -55,6 +56,7 @@ fun AppNavigation() {
                 folderId = folderId,
                 onMediaSelected = { mediaItem ->
                     if (mediaItem.isVideo) {
+                        sharedViewModel.setFullscreenTransition(true)
                         navController.navigate("player/${mediaItem.id}")
                     }
                 },

--- a/app/src/main/java/com/example/tvmoview/presentation/player/SharedPlayerManager.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/player/SharedPlayerManager.kt
@@ -1,0 +1,37 @@
+package com.example.tvmoview.presentation.player
+
+import android.content.Context
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+object SharedPlayerManager {
+    private var sharedPlayer: ExoPlayer? = null
+    private val _currentVideoId = MutableStateFlow<String?>(null)
+    val currentVideoId: StateFlow<String?> = _currentVideoId
+
+    fun getOrCreatePlayer(context: Context, videoId: String): ExoPlayer {
+        return if (sharedPlayer != null && _currentVideoId.value == videoId) {
+            sharedPlayer!!
+        } else {
+            releasePlayer()
+            ExoPlayer.Builder(context).build().also {
+                sharedPlayer = it
+                _currentVideoId.value = videoId
+            }
+        }
+    }
+
+    fun transferPlayer(): ExoPlayer? {
+        val player = sharedPlayer
+        sharedPlayer = null
+        return player
+    }
+
+    fun releasePlayer() {
+        sharedPlayer?.release()
+        sharedPlayer = null
+        _currentVideoId.value = null
+    }
+}

--- a/app/src/main/java/com/example/tvmoview/presentation/player/SharedPlayerManager.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/player/SharedPlayerManager.kt
@@ -29,6 +29,14 @@ object SharedPlayerManager {
         return player
     }
 
+    fun isCurrentVideo(videoId: String): Boolean {
+        return sharedPlayer != null && _currentVideoId.value == videoId
+    }
+
+    fun getCurrentPosition(): Long {
+        return sharedPlayer?.currentPosition ?: 0L
+    }
+
     fun releasePlayer() {
         sharedPlayer?.release()
         sharedPlayer = null

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
@@ -45,21 +45,29 @@ fun HighQualityPlayerScreen(
     viewModel: MediaBrowserViewModel,
     downloadUrl: String = ""
 ) {
+    Log.d("VideoPlayer", "🚀 HighQualityPlayerScreen開始: $itemId")
+
     val context = LocalContext.current
     val focusRequester = remember { FocusRequester() }
     val coroutineScope = rememberCoroutineScope()
 
     val resolvedUrl by produceState<String?>(null, itemId) {
+        Log.d("VideoPlayer", "\uD83D\uDCE1 URL解決開始")
         val cachedUrl = viewModel.currentVideoUrl.value
         if (cachedUrl != null && SharedPlayerManager.currentVideoId.value == itemId) {
+            Log.d("VideoPlayer", "\u2705 キャッシュURL使用: ${cachedUrl.take(50)}...")
             value = cachedUrl
         } else {
+            Log.d("VideoPlayer", "\uD83D\uDD04 新規URL取得開始")
             value = resolveVideoUrl(itemId, downloadUrl)
         }
+        Log.d("VideoPlayer", "\uD83D\uDCE1 URL解決完了")
     }
 
     val itemInfo by produceState<DomainMediaItem?>(null, itemId) {
-        value = MainActivity.oneDriveRepository.getItemById(itemId)
+        if (SharedPlayerManager.currentVideoId.value != itemId) {
+            value = MainActivity.oneDriveRepository.getItemById(itemId)
+        }
     }
 
     // カスタムシークバー表示制御
@@ -69,7 +77,7 @@ fun HighQualityPlayerScreen(
     var seekMessage by remember { mutableStateOf("") }
     var seekForward by remember { mutableStateOf(true) }
 
-    var showCover by remember { mutableStateOf(SharedPlayerManager.currentVideoId.value != itemId) }
+    var showCover by remember { mutableStateOf(false) }
     var bufferProgress by remember { mutableFloatStateOf(0f) }
 
     // PlayerView参照用とコントローラー制御
@@ -88,9 +96,12 @@ fun HighQualityPlayerScreen(
     }
 
     LaunchedEffect(resolvedUrl) {
+        Log.d("VideoPlayer", "\uD83C\uDFAC Player初期化開始")
         releasePlayer()
         val transferredPlayer = SharedPlayerManager.transferPlayer()
+
         val isTransferred = transferredPlayer != null && SharedPlayerManager.currentVideoId.value == itemId
+        Log.d("VideoPlayer", "\uD83D\uDD04 転送プレイヤー: $isTransferred")
 
         exoPlayer = if (isTransferred) {
             showCover = false
@@ -295,8 +306,8 @@ fun HighQualityPlayerScreen(
             )
         } ?: LoadingAnimation()
 
-        if (showCover) {
-            val thumb = itemInfo?.thumbnailUrl
+        if (showCover && itemInfo != null) {
+            val thumb = itemInfo.thumbnailUrl
             thumb?.let { url ->
                 SubcomposeAsyncImage(
                     model = ImageRequest.Builder(context)

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
@@ -306,8 +306,9 @@ fun HighQualityPlayerScreen(
             )
         } ?: LoadingAnimation()
 
-        if (showCover && itemInfo != null) {
-            val thumb = itemInfo.thumbnailUrl
+        val info = itemInfo
+        if (showCover && info != null) {
+            val thumb = info.thumbnailUrl
             thumb?.let { url ->
                 SubcomposeAsyncImage(
                     model = ImageRequest.Builder(context)

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
@@ -49,8 +49,13 @@ fun HighQualityPlayerScreen(
     val focusRequester = remember { FocusRequester() }
     val coroutineScope = rememberCoroutineScope()
 
-    val resolvedUrl by produceState<String?>(null, itemId, downloadUrl) {
-        value = resolveVideoUrl(itemId, downloadUrl)
+    val resolvedUrl by produceState<String?>(null, itemId) {
+        val cachedUrl = viewModel.currentVideoUrl.value
+        if (cachedUrl != null && SharedPlayerManager.currentVideoId.value == itemId) {
+            value = cachedUrl
+        } else {
+            value = resolveVideoUrl(itemId, downloadUrl)
+        }
     }
 
     val itemInfo by produceState<DomainMediaItem?>(null, itemId) {
@@ -64,7 +69,7 @@ fun HighQualityPlayerScreen(
     var seekMessage by remember { mutableStateOf("") }
     var seekForward by remember { mutableStateOf(true) }
 
-    var showCover by remember { mutableStateOf(true) }
+    var showCover by remember { mutableStateOf(SharedPlayerManager.currentVideoId.value != itemId) }
     var bufferProgress by remember { mutableFloatStateOf(0f) }
 
     // PlayerView参照用とコントローラー制御

--- a/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/screens/HighQualityPlayerScreen.kt
@@ -90,13 +90,16 @@ fun HighQualityPlayerScreen(
     LaunchedEffect(resolvedUrl) {
         releasePlayer()
         val transferredPlayer = SharedPlayerManager.transferPlayer()
+        val isTransferred = transferredPlayer != null && SharedPlayerManager.currentVideoId.value == itemId
 
-        exoPlayer = if (transferredPlayer != null && SharedPlayerManager.currentVideoId.value == itemId) {
-            transferredPlayer.apply {
+        exoPlayer = if (isTransferred) {
+            showCover = false
+            transferredPlayer!!.apply {
                 volume = 1f
                 repeatMode = ExoPlayer.REPEAT_MODE_OFF
             }
         } else {
+            showCover = true
             resolvedUrl?.let { url ->
                 ExoPlayer.Builder(context).build().apply {
                     setMediaItem(MediaItem.fromUri(url))
@@ -113,17 +116,15 @@ fun HighQualityPlayerScreen(
             }
         }
         playerView?.player = exoPlayer
-        showCover = true
         viewModel.setFullscreenTransition(false)
     }
     LaunchedEffect(playerView, exoPlayer) {
         playerView?.player = exoPlayer
     }
 
-    LaunchedEffect(exoPlayer) {
+    LaunchedEffect(exoPlayer, showCover) {
         val player = exoPlayer
-        if (player != null) {
-            showCover = true
+        if (player != null && showCover) {
             val listener = object : Player.Listener {
                 override fun onPlaybackStateChanged(state: Int) {
                     if (state == Player.STATE_READY) showCover = false

--- a/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
@@ -83,6 +83,13 @@ class MediaBrowserViewModel : ViewModel() {
     private val _isTransitioningToFullscreen = MutableStateFlow(false)
     val isTransitioningToFullscreen: StateFlow<Boolean> = _isTransitioningToFullscreen
 
+    private val _currentVideoUrl = MutableStateFlow<String?>(null)
+    val currentVideoUrl: StateFlow<String?> = _currentVideoUrl.asStateFlow()
+
+    fun setCurrentVideoUrl(url: String?) {
+        _currentVideoUrl.value = url
+    }
+
     fun setFullscreenTransition(isTransitioning: Boolean) {
         _isTransitioningToFullscreen.value = isTransitioning
     }

--- a/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
+++ b/app/src/main/java/com/example/tvmoview/presentation/viewmodels/MediaBrowserViewModel.kt
@@ -80,6 +80,13 @@ class MediaBrowserViewModel : ViewModel() {
     private val _previewVideoId = MutableStateFlow<String?>(null)
     val previewVideoId: StateFlow<String?> = _previewVideoId.asStateFlow()
 
+    private val _isTransitioningToFullscreen = MutableStateFlow(false)
+    val isTransitioningToFullscreen: StateFlow<Boolean> = _isTransitioningToFullscreen
+
+    fun setFullscreenTransition(isTransitioning: Boolean) {
+        _isTransitioningToFullscreen.value = isTransitioning
+    }
+
     fun updatePreviewPosition(videoId: String, position: Long) {
         _previewVideoId.value = videoId
         _previewPlaybackPosition.value = position


### PR DESCRIPTION
## Summary
- share ExoPlayer instance between preview and fullscreen
- expose transition state in `MediaBrowserViewModel`
- keep player during navigation from preview
- reuse player in `HighQualityPlayerScreen`
- update navigation to set transition flag

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6872080ffe54832cbbd5fdede9a1cca2